### PR TITLE
Support union and intersection

### DIFF
--- a/src/me/vedang/bloomclj/core.clj
+++ b/src/me/vedang/bloomclj/core.clj
@@ -71,4 +71,6 @@
   "Define the set of functions that should be implemented by a Bloom Filter."
   (add [this elem])
   (maybe-contains? [this elem])
-  (clear [this]))
+  (clear [this])
+  (union [this other])
+  (intersection [this other]))

--- a/test/me/vedang/bloomclj/redis_backed_test.clj
+++ b/test/me/vedang/bloomclj/redis_backed_test.clj
@@ -1,0 +1,35 @@
+(ns me.vedang.bloomclj.redis-backed-test
+  (:require [me.vedang.bloomclj.core :refer :all]
+            [me.vedang.bloomclj.redis-backed :refer :all]
+            [clojure.test :refer :all]))
+
+(def tbf1 (redis-backed-bloom-filter 1000000 0.01 "127.0.0.1" 6379))
+(add tbf1 "hello")
+(add tbf1 "world")
+
+(def tbf2 (redis-backed-bloom-filter 1000000 0.01 "127.0.0.1" 6379))
+(add tbf2 "goodbye")
+(add tbf2 "world")
+
+(deftest direct-addition-test
+  ;; hello world
+  (is (maybe-contains? tbf1 "hello"))
+  (is (not (maybe-contains? tbf1 "goodbye")))
+  (is (maybe-contains? tbf1 "world"))
+  ;; goodbye world
+  (is (not (maybe-contains? tbf2 "hello")))
+  (is (maybe-contains? tbf2 "goodbye"))
+  (is (maybe-contains? tbf2 "world")))
+
+(deftest union-test
+  (let [tbf3 (union tbf1 tbf2)]
+    (is (maybe-contains? tbf3 "hello"))
+    (is (maybe-contains? tbf3 "goodbye"))
+    (is (maybe-contains? tbf3 "world"))))
+
+(deftest intersection-test
+  (let [tbf4 (intersection tbf1 tbf2)]
+    (is (not (maybe-contains? tbf4 "hello")))
+    (is (not (maybe-contains? tbf4 "goodbye")))
+    (is (maybe-contains? tbf4 "world"))))
+

--- a/test/me/vedang/bloomclj/transient_test.clj
+++ b/test/me/vedang/bloomclj/transient_test.clj
@@ -1,0 +1,35 @@
+(ns me.vedang.bloomclj.transient-test
+  (:require [me.vedang.bloomclj.core :refer :all]
+            [me.vedang.bloomclj.transient :refer :all]
+            [clojure.test :refer :all]))
+
+(def tbf1 (transient-bloom-filter 1000000 0.01))
+(add tbf1 "hello")
+(add tbf1 "world")
+
+(def tbf2 (transient-bloom-filter 1000000 0.01))
+(add tbf2 "goodbye")
+(add tbf2 "world")
+
+(deftest direct-addition-test
+  ;; hello world
+  (is (maybe-contains? tbf1 "hello"))
+  (is (not (maybe-contains? tbf1 "goodbye")))
+  (is (maybe-contains? tbf1 "world"))
+  ;; goodbye world
+  (is (not (maybe-contains? tbf2 "hello")))
+  (is (maybe-contains? tbf2 "goodbye"))
+  (is (maybe-contains? tbf2 "world")))
+
+(deftest union-test
+  (let [tbf3 (union tbf1 tbf2)]
+    (is (maybe-contains? tbf3 "hello"))
+    (is (maybe-contains? tbf3 "goodbye"))
+    (is (maybe-contains? tbf3 "world"))))
+
+(deftest intersection-test
+  (let [tbf4 (intersection tbf1 tbf2)]
+    (is (not (maybe-contains? tbf4 "hello")))
+    (is (not (maybe-contains? tbf4 "goodbye")))
+    (is (maybe-contains? tbf4 "world"))))
+


### PR DESCRIPTION
Refs: https://github.com/vedang/bloomclj/issues/2

Note that I didn't need to use formulas linked - those are only for the cardinality. 

Since union and intersection have such trivial formulas (if the parameters of the filters are the same - just assumed), I've implemented them directly.

Even if this library wanted to add a `cardinality` function, you'd only need to implement those formulas linked to if you wanted to skip creation of the related intersection / union filter. 

(or possibly the intersection cardinality function is more accurate than the cardinality of the intersected filter?)
